### PR TITLE
Use "type": "wp-cli-package" to designate this as a WP-CLI package

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,6 @@
 {
 	"name": "ernilambar/database-command",
-	"type": "command",
+	"type": "wp-cli-package",
 	"description": "Tool to reset WordPress database. This reset WP database but retains given administrator user account.",
 	"homepage": "https://github.com/ernilambar/database-command",
 	"keywords": ["wp-cli","database"],


### PR DESCRIPTION
See https://github.com/wp-cli/wp-cli/issues/2567
